### PR TITLE
Hardcoding postgres versions is bad.

### DIFF
--- a/fetch_usage_from_ccdb.sh
+++ b/fetch_usage_from_ccdb.sh
@@ -51,7 +51,7 @@ PSQL_URL=postgresql://localhost:3306/cloud_controller
 bosh \
     ssh -d cf_databases ccdb/0 "
     sudo -u vcap -i \
-    /var/vcap/packages/postgres-9.6.3/bin/psql ${PSQL_URL} \
+    ( /var/vcap/packages/postgres-*/bin/psql ) ${PSQL_URL} \
     -c \"
         COPY (SELECT guid, created_at, instance_count, memory_in_mb_per_instance, state, app_guid, app_name, space_guid, space_name, org_guid, buildpack_guid, buildpack_name, package_state, parent_app_name, parent_app_guid, process_type, task_guid, task_name, package_guid, previous_state, previous_package_state, previous_memory_in_mb_per_instance, previous_instance_count FROM app_usage_events) TO '/tmp/app_usage_events.csv';
         COPY (SELECT guid, created_at, updated_at, name, billing_enabled, quota_definition_id, status, default_isolation_segment_guid FROM organizations) TO '/tmp/organizations.csv';


### PR DESCRIPTION
Hardcoding the postgres version was a bad idea. It assumed that we'd never update anything. We did. It broke.
This magical glob pattern should theoretically return only a single match (at least it did in my testing), so no matter how many different postgres versions exist on a box, it should only match a single psql binary.