### PR TITLE
Dynamically find path to psql.

### DIFF
--- a/fetch_usage_from_ccdb.sh
+++ b/fetch_usage_from_ccdb.sh
@@ -47,8 +47,9 @@ ssh_init() {
 trap ssh_cleanup EXIT
 ssh_init
 
-PSQL_PATH=$(bosh ssh -d cf_databases ccdb/0 'find /var/vcap/ -name psql' | grep psql | awk {'print $4'})
+PSQL_PATH=$(bosh ssh -d cf_databases ccdb/0 'find -L /var/vcap/packages -name psql' | grep psql | awk '{print $4}')
 if [ -n "${PSQL_PATH}" ]; then
+  PSQL_PATH=$(echo "${PSQL_PATH}" | tr -dc '[:print:]')
   echo "PSQL Found at ${PSQL_PATH}"
 else
   echo "Failed to find psql binary - Code might need fixing. Exiting!! "


### PR DESCRIPTION
### What
Due to complexities with variable expansion over a bosh ssh session, we formerly had a hardcoded path to the `psql` binary built into this script. This would fail several times a year as postgres versions moved forward.

This PR implements a new strategy of splitting the bosh operations into two steps. The first step is to find the `psql` binary and store the result in a variable within the script. Due to the way that bosh delivers it's output, it is necessary to strip non-printable characters from the variable before it can be used. (The non-printable chars caused me so much confusion during implementation).
The second bosh step is now able to use the `PSQL_PATH` variable that we created in step 1 as the path to the `psql` binary, rather than having a hardcoded path.

As an added bonus, this PR also means that the script will work even when we have different postgres versions across foundations rather than them all having to move forward together in lock-step.

### How to review
Inspect the code. 
Run shellcheck over it (although I already did that).
Take a look at the app-usage-reports pipeline and see that the job has succeeded.
Hit merge.
Re-push cf-utils pipeline from master branch (as currently it is tweaked to pull cf-app-usage-report-sql from this branch)
Be happy

### Who can review?
Anyone but Jim.