### PR TITLE
We only want a single psql binary - adding the -quit flag to find

### DIFF
--- a/fetch_usage_from_ccdb.sh
+++ b/fetch_usage_from_ccdb.sh
@@ -47,7 +47,7 @@ ssh_init() {
 trap ssh_cleanup EXIT
 ssh_init
 
-PSQL_PATH=$(bosh ssh -d cf_databases ccdb/0 'find -L /var/vcap/packages -name psql' | grep psql | awk '{print $4}')
+PSQL_PATH=$(bosh ssh -d cf_databases ccdb/0 'find -L /var/vcap/packages -name psql -quit' | grep psql | awk '{print $4}')
 if [ -n "${PSQL_PATH}" ]; then
   PSQL_PATH=$(echo "${PSQL_PATH}" | tr -dc '[:print:]')
   echo "PSQL Found at ${PSQL_PATH}"


### PR DESCRIPTION
Add the -quit flag to the find command so that it only returns a single result.